### PR TITLE
Refactor README and update migration publishing tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 ![Laravel Model Metadata](lmm.jpg)
 
-
 # Laravel Model Metadata
-A Laravel package designed to manage metadata with JSON support multiple data types. This package allows you to easily attach, manage, and query metadata on your Laravel models.
-can use `HasManyMetadata` or `HasOneMetadata` trait to manage metadata.
+
+Laravel Model Metadata is a package designed to manage metadata with JSON support for multiple data types. It allows you to easily attach, manage, and query metadata on your Laravel models using the `HasManyMetadata` or `HasOneMetadata` traits.
 
 ## ✨ Requirements
 
@@ -11,16 +10,21 @@ can use `HasManyMetadata` or `HasOneMetadata` trait to manage metadata.
 - Laravel 10.0 or higher
 - JSON extension enabled
 
-
 ## 💼 Installation
+
 1. Install the package using Composer:
    ```bash
    composer require waad/laravel-model-metadata
    ```
 
-2. Publish the migrations file:
+2. Publish the migration files:
    ```bash
-   php artisan vendor:publish --provider="Waad\\Metadata\\Providers\\MetadataServiceProvider" --tag="migrations"
+   php artisan vendor:publish --tag=metadata-migrations
+   ```
+
+3. Run the migrations:
+   ```bash
+   php artisan migrate
    ```
 
 ## 🎈 Usage

--- a/src/Providers/MetadataServiceProvider.php
+++ b/src/Providers/MetadataServiceProvider.php
@@ -20,6 +20,6 @@ class MetadataServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__ . '/../../migrations/1_create_model_meta_data_table.php' => 
                 database_path('migrations/'. date('Y_m_d_His', time()) .'_create_model_meta_data_table.php'),
-        ], 'migrations');
+        ], 'metadata-migrations');
     }
 }


### PR DESCRIPTION
- Improved the description of the Laravel Model Metadata package for clarity and conciseness.
- Updated installation instructions to reflect the correct terminology for migration files.
- Changed the migration publishing tag in the MetadataServiceProvider to 'metadata-migrations' for consistency.