### PR TITLE
Refactor HasManyMetadata trait and enhance tests for metadata retrieval

### DIFF
--- a/src/Traits/HasManyMetadata.php
+++ b/src/Traits/HasManyMetadata.php
@@ -11,10 +11,6 @@ use Waad\Metadata\Models\Metadata;
 
 trait HasManyMetadata
 {
-    public $metadataNameIdEnabled = true;
-
-    public $metadataNameId = 'id';
-
     public function setMetadataNameIdEnabled(bool $metadataNameIdEnabled): self
     {
         $this->metadataNameIdEnabled = $metadataNameIdEnabled;
@@ -24,7 +20,7 @@ trait HasManyMetadata
 
     public function getMetadataNameIdEnabled(): bool
     {
-        return $this->metadataNameIdEnabled;
+        return isset($this->metadataNameIdEnabled) ? $this->metadataNameIdEnabled : true;
     }
 
     public function setMetadataNameId(string $metadataNameId): self
@@ -36,7 +32,7 @@ trait HasManyMetadata
 
     public function getMetadataNameId(): string
     {
-        return $this->metadataNameId;
+        return isset($this->metadataNameId) ? $this->metadataNameId : 'id';
     }
 
     /**

--- a/tests/Feature/HasManyMetadataTest.php
+++ b/tests/Feature/HasManyMetadataTest.php
@@ -424,6 +424,42 @@ it('can retrieve metadata as a collection using getMetadataCollection', function
         ->and($metadataCollection->get(0)['language'])->toBeString()->toBe('Arabic');
 });
 
+// Test to ensure metadata can be retrieved as an array
+it('can retrieve metadata as an array using getMetadata', function () {
+    // Create metadata for the post
+    $metadataCollection = $this->post->createManyMetadata([
+        [
+            'theme' => 'dark',
+            'language' => 'Arabic',
+        ],
+        [
+            'theme' => 'light',
+            'language' => 'English',
+        ],
+    ]);
+    expect($metadataCollection)->toBeCollection()->toHaveCount(2);
+
+    // Retrieve the metadata collection
+    $metadata = $this->post->getMetadata();
+    expect($metadata)->toBeArray()->toHaveCount(2);
+    expect($metadata[0])->toMatchArray(['theme' => 'dark', 'language' => 'Arabic']);
+    expect($metadata[1])->toMatchArray(['theme' => 'light', 'language' => 'English']);
+
+    // change metadata name id
+    $this->post->setMetadataNameId('metadata_id');
+    $metadata = $this->post->getMetadata();
+    expect($metadata)->toBeArray()->toHaveCount(2);
+    expect($metadata[0])->toMatchArray(['metadata_id' => $metadataCollection[0]->id, 'theme' => 'dark', 'language' => 'Arabic']);
+    expect($metadata[1])->toMatchArray(['metadata_id' => $metadataCollection[1]->id, 'theme' => 'light', 'language' => 'English']);
+
+    // change metadata name id enabled
+    $this->post->setMetadataNameIdEnabled(false);
+    $metadata = $this->post->getMetadata();
+    expect($metadata)->toBeArray()->toHaveCount(2);
+    expect($metadata[0])->toMatchArray(['theme' => 'dark', 'language' => 'Arabic']);
+    expect($metadata[1])->toMatchArray(['theme' => 'light', 'language' => 'English']);
+});
+
 it('can retrieve metadata by ID using getMetadataById', function () {
     // Create metadata for the post
     $metadata = $this->post->createMetadata([


### PR DESCRIPTION
- Removed properties `$metadataNameIdEnabled` and `$metadataNameId` from the trait.
- Updated getter methods to provide default values if properties are not set.
- Added new tests to verify metadata retrieval as an array, including scenarios for changing metadata name ID and enabling/disabling metadata name ID.